### PR TITLE
Shut down Socat container alongside FoundationDB container

### DIFF
--- a/src/main/java/earth/adi/testcontainers/containers/FoundationDBContainer.java
+++ b/src/main/java/earth/adi/testcontainers/containers/FoundationDBContainer.java
@@ -142,6 +142,14 @@ public class FoundationDBContainer extends GenericContainer<FoundationDBContaine
         proxyBindPort(INTERNAL_PORT, bindPort);
     }
 
+    @Override
+    public void stop() {
+        if (this.proxy != null) {
+            this.proxy.stop();
+        }
+        super.stop();
+    }
+
     @SneakyThrows
     private void proxyBindPort(final int listenPort, final int mappedPort) {
         final ExecCreateCmdResponse createCmdResponse = dockerClient


### PR DESCRIPTION
This PR introduces an override of the stop method in the FoundationDBContainer class to ensure that the Socat container is properly stopped when the FoundationDB container is stopped.